### PR TITLE
Remove request reversal in volume loadImages to preserve spatial load order

### DIFF
--- a/packages/core/src/cache/classes/BaseStreamingImageVolume.ts
+++ b/packages/core/src/cache/classes/BaseStreamingImageVolume.ts
@@ -535,7 +535,7 @@ export class BaseStreamingImageVolume
 
     const requests = this.getImageLoadRequests(5);
 
-    requests.reverse().forEach((request) => {
+    requests.forEach((request) => {
       if (!request) {
         // there is a cached image for the imageId and no requests will fire
         return;


### PR DESCRIPTION
## Summary

- Remove `.reverse()` call on load requests in `BaseStreamingImageVolume.loadImages` so dynamic volume instances stream in their natural spatial order
- Fixes the issue where the last physical slice rendered first during streaming, causing a visually jarring load sequence
- The `.reverse()` was originally added in Cornerstone3D 2.0 when the `requestPoolManager` processed requests in LIFO order. That was later changed to FIFO, making the reversal incorrect and causing this legacy bug

## Related

- Viewer PR: https://github.com/gradienthealth/Viewers/pull/106

## Test plan

- [ ] Load a dynamic volume (e.g. 4D PET or perfusion CT) and verify slices stream from the first timepoint onward
- [ ] Verify static 3D volumes are unaffected
- [ ] Verify load completion callbacks and `IMAGE_VOLUME_LOADING_COMPLETED` still fire correctly
