### PR TITLE
Remove request reversal in volume loadImages to preserve spatial load order

### DIFF
--- a/packages/core/src/cache/classes/BaseStreamingImageVolume.ts
+++ b/packages/core/src/cache/classes/BaseStreamingImageVolume.ts
@@ -535,7 +535,7 @@ export class BaseStreamingImageVolume
 
     const requests = this.getImageLoadRequests(5);
 
-    requests.reverse().forEach((request) => {
+    requests.forEach((request) => {
       if (!request) {
         // there is a cached image for the imageId and no requests will fire
         return;


### PR DESCRIPTION
Related to Viewer PR [#106](https://github.com/gradienthealth/Viewers/pull/106)